### PR TITLE
Actualización de Normalize

### DIFF
--- a/openket/core/metrics.py
+++ b/openket/core/metrics.py
@@ -142,7 +142,7 @@ def Normalize(state):
     """
     norm = (Adj(state)*state)
     norm = float(norm)
-    state = state / (norm**0.5)
+    state = state *norm**-0.5
     return state
 
 def Qmatrix(A, basis = 'default'):


### PR DESCRIPTION
Tener una división arroja un error, por lo que se propone cambiar a una multiplicación